### PR TITLE
feat: support dubbo registry rule

### DIFF
--- a/example/dubbo.js
+++ b/example/dubbo.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const { RpcClient } = require('../').client;
+const { ZookeeperRegistry } = require('../').registry;
+const protocol = require('dubbo-remoting');
+const logger = console;
+
+const registry = new ZookeeperRegistry({
+  logger,
+  address: '127.0.0.1:2181/dubbo/',
+});
+
+async function invoke() {
+  const client = new RpcClient({
+    logger,
+    registry,
+    protocol,
+    group: 'dubbo',
+    version: null,
+  });
+  const consumer = client.createConsumer({
+    interfaceName: 'org.apache.dubbo.demo.DemoService',
+  });
+  await consumer.ready();
+
+  const result = await consumer.invoke('sayHello', [{
+    $class: 'java.lang.String',
+    $: 'zongyu',
+  }], { responseTimeout: 3000 });
+  console.log(result);
+}
+
+invoke().catch(console.error);

--- a/lib/client/consumer.js
+++ b/lib/client/consumer.js
@@ -30,7 +30,7 @@ class RpcConsumer extends Base {
   }
 
   get id() {
-    return this.interfaceName + ':' + this.version;
+    return this.version ? this.interfaceName + ':' + this.version : this.interfaceName;
   }
 
   get interfaceName() {

--- a/lib/registry/zk/data_client.js
+++ b/lib/registry/zk/data_client.js
@@ -29,7 +29,7 @@ class ZookeeperRegistry extends Base {
       if (!this._rootPath.endsWith('/')) this._rootPath += '/';
     } else {
       address = options.address;
-      this._rootPath = '/';
+      this._rootPath = '/sofa-rpc/';
     }
     this._zkClient = this.options.zookeeper.createClient(address);
     this._subscribeMap = new Map(); // <interfaceName, addressList>
@@ -129,11 +129,11 @@ class ZookeeperRegistry extends Base {
   }
 
   _buildProviderPath(config) {
-    return this._rootPath + 'sofa-rpc/' + config.interfaceName + '/providers';
+    return this._rootPath + config.interfaceName + '/providers';
   }
 
   _buildConsumerPath(config) {
-    return this._rootPath + 'sofa-rpc/' + config.interfaceName + '/consumers';
+    return this._rootPath + config.interfaceName + '/consumers';
   }
 
   close() {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "autod": "autod",
     "lint": "eslint . --ext .js",
-    "cov": "TEST_TIMEOUT=10000 egg-bin cov",
+    "cov": "TEST_TIMEOUT=20000 egg-bin cov",
     "test": "npm run lint && npm run test-local",
     "test-local": "egg-bin test",
     "pkgfiles": "egg-bin pkgfiles --check",
@@ -54,8 +54,9 @@
     "await-event": "^2.1.0",
     "coffee": "^5.1.0",
     "contributors": "^0.5.1",
+    "dubbo-remoting": "^2.1.2",
     "egg-bin": "^4.9.0",
-    "eslint": "^5.7.0",
+    "eslint": "^5.8.0",
     "eslint-config-egg": "^7.1.0",
     "mm": "^2.4.1",
     "pedding": "^1.1.0"

--- a/test/client/consumer.test.js
+++ b/test/client/consumer.test.js
@@ -50,6 +50,7 @@ describe('test/client/consumer.test.js', () => {
     });
     assert(consumer.logger);
     await consumer.ready();
+    assert(consumer.id === 'com.alipay.sofa.rpc.test.ProtoService:1.0');
     const args = [{
       name: 'Peter',
       group: 'A',
@@ -341,7 +342,6 @@ describe('test/client/consumer.test.js', () => {
     consumer.close();
   });
 
-
   it('should throw BizError', async function() {
     const consumer = new RpcConsumer({
       interfaceName: 'com.alipay.sofa.rpc.test.ProtoService',
@@ -394,5 +394,21 @@ describe('test/client/consumer.test.js', () => {
     console.log(res.error);
     assert(!res.appResponse);
     consumer.close();
+  });
+
+  it('should support consumer without version', async function() {
+    const consumer = new RpcConsumer({
+      interfaceName: 'com.alipay.sofa.rpc.test.ProtoService',
+      version: null,
+      connectionManager,
+      connectionOpts: {
+        protocol,
+      },
+      registry,
+      logger,
+    });
+    assert(consumer.logger);
+    await consumer.ready();
+    assert(consumer.id === 'com.alipay.sofa.rpc.test.ProtoService');
   });
 });

--- a/test/client/fault_retry.test.js
+++ b/test/client/fault_retry.test.js
@@ -7,7 +7,7 @@ const AddressGroup = require('../../lib/client/address_group');
 const ConnectionManager = require('../../lib/client/connection_mgr');
 const logger = console;
 
-describe('test/fault_retry.test.js', () => {
+describe('test/client/fault_retry.test.js', () => {
   let connectionManager;
   before(() => {
     connectionManager = new ConnectionManager({ logger });
@@ -18,7 +18,6 @@ describe('test/fault_retry.test.js', () => {
   });
 
   it('should retry fault ok', async function() {
-    this.timeout(20000);
     const addressGroup = new AddressGroup({
       key: 'fault',
       logger,
@@ -45,7 +44,9 @@ describe('test/fault_retry.test.js', () => {
 
     addressGroup.addressList = [];
 
-    setTimeout(() => { addressGroup.emit('timeout'); }, 10000);
+    setTimeout(() => {
+      addressGroup.emit('timeout');
+    }, 9000);
 
     const o = await addressGroup.awaitFirst([ 'retry', 'timeout' ]);
     assert(o.event === 'timeout');


### PR DESCRIPTION
如果是 dubbo zk 注册中心，需要在 connectionString 后面加上 `/dubbo/` 路径。

```
// 例子：（如果是集群模式，也只需要在最后加上 /dubbo/ 即可）
standalone => 127.0.0.1:2181/dubbo/
cluster => 127.0.0.1:2181,127.0.0.2:2181,127.0.0.3:2181/dubbo/
```

```js
'use strict';

const logger = console;
const { ZookeeperRegistry } = require('sofa-node-rpc').registry;

const registry = new ZookeeperRegistry({
  logger,
  address: '127.0.0.1:2181/dubbo/',  // 注意：这里需要以 /dubbo/ 结尾
});
```